### PR TITLE
fix(backend): noop migration for feeds.link unique (already exists)

### DIFF
--- a/backend/database/migrations/2025_09_28_024910_create_feeds_table.php
+++ b/backend/database/migrations/2025_09_28_024910_create_feeds_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('feeds', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->string('link')->unique();
+            $table->string('source')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+    });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('feeds');
+    }
+};

--- a/backend/database/migrations/2025_10_01_003706_migrate_feeds_published_at_and_unique.php
+++ b/backend/database/migrations/2025_10_01_003706_migrate_feeds_published_at_and_unique.php
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        // No-Op: feeds.link の UNIQUE は既に存在
+    }
+
+    public function down(): void
+    {
+        Schema::table('feeds', function (Blueprint $table) {
+            // ✅ デフォルト名で作ったUNIQUEは、カラム配列で外す
+            $table->dropUnique(['link']);
+        });
+    }
+};


### PR DESCRIPTION
	•	feeds.link に UNIQUE 制約を付けた
	•	既に存在していたので今回のマイグレーションは No-Op 化
	•	php artisan migrate 済み、重複挿入が弾かれることを確認済み